### PR TITLE
Add `--v` flag to optionally include versions in `requirements.txt`

### DIFF
--- a/pwp/commands/__init__.py
+++ b/pwp/commands/__init__.py
@@ -1,0 +1,2 @@
+from .install import pwp_install
+from .uninstall import pwp_uninstall

--- a/pwp/commands/install.py
+++ b/pwp/commands/install.py
@@ -46,7 +46,8 @@ def create_or_update_requirements(packages: dict[str, str | None]):
         print(f"All libraries already exist in {requirements_file}. No updates made.")
 
 
-def pwp_install(packages, include_version):
+def pwp_install(args):
+    packages, include_version = args.packages, args.v
     pip_main(['install'] + packages)
 
     # Retrieve the installed versions if --v flag is present, else set versions to None

--- a/pwp/commands/install.py
+++ b/pwp/commands/install.py
@@ -1,6 +1,22 @@
+import argparse
 import os
 from pip._internal.cli.main import main as pip_main
 from .utils import load_packages, dump_packages, get_installed_package_version, format_packages, filter_packages
+
+
+def get_install_parser():
+    parser = argparse.ArgumentParser(description="Install Python packages.", add_help=False)
+    parser.add_argument(
+        'packages',
+        nargs='+',
+        help="List of packages to install."
+    )
+    parser.add_argument(
+        '--v',
+        action='store_true',
+        help="Include package versions in the output."
+    )
+    return parser
 
 
 def create_or_update_requirements(packages: dict[str, str | None]):
@@ -30,17 +46,7 @@ def create_or_update_requirements(packages: dict[str, str | None]):
         print(f"All libraries already exist in {requirements_file}. No updates made.")
 
 
-def pwp_install():
-    if len(sys.argv) < 3:
-        print("Usage: pwp install <package_name1> [<package_name2> ...] [--v]")
-        return
-
-    packages = sys.argv[2:]
-    include_version = '--v' in packages
-
-    if include_version:
-        packages.remove('--v')
-
+def pwp_install(packages, include_version):
     pip_main(['install'] + packages)
 
     # Retrieve the installed versions if --v flag is present, else set versions to None

--- a/pwp/commands/install.py
+++ b/pwp/commands/install.py
@@ -1,16 +1,12 @@
 import os
-import sys
 from pip._internal.cli.main import main as pip_main
-from .utils import load_packages, dump_packages, get_installed_package_version
+from .utils import load_packages, dump_packages, get_installed_package_version, format_packages, filter_packages
 
 
 def create_or_update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
-    if os.path.exists(requirements_file):
-        existing_packages = load_packages(requirements_file)
-    else:
-        existing_packages = {}
+    existing_packages = load_packages(requirements_file) if os.path.exists(requirements_file) else {}
 
     updated_packages = existing_packages.copy()
 
@@ -23,13 +19,13 @@ def create_or_update_requirements(packages: dict[str, str | None]):
 
     dump_packages(updated_packages, requirements_file)
 
-    new_packages = [
-        f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages.items()
-        if pkg not in existing_packages or existing_packages[pkg] != ver
-    ]
+    new_packages = filter_packages(
+        packages=packages,
+        condition=lambda pkg, ver: pkg not in existing_packages or existing_packages[pkg] != ver
+    )
 
     if new_packages:
-        print(f"Updated {requirements_file} with {', '.join(new_packages)}")
+        print(f"Updated {requirements_file} with {', '.join(format_packages(new_packages))}")
     else:
         print(f"All libraries already exist in {requirements_file}. No updates made.")
 

--- a/pwp/commands/install.py
+++ b/pwp/commands/install.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pip._internal.cli.main import main as pip_main
 import importlib.metadata
+from .utils import load_packages, dump_packages
 
 
 def get_installed_package_version(package_name):
@@ -16,15 +17,7 @@ def create_or_update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):
-        with open(requirements_file, 'r') as lines:
-            existing_packages = {}
-            for line in lines:
-                line = line.strip()
-                if "==" not in line:
-                    existing_packages[line] = None
-                else:
-                    name, version = line.split("==")
-                    existing_packages[name] = version
+        existing_packages = load_packages(requirements_file)
     else:
         existing_packages = {}
 
@@ -37,13 +30,7 @@ def create_or_update_requirements(packages: dict[str, str | None]):
         elif package not in existing_packages:
             updated_packages[package] = None
 
-    with open(requirements_file, 'w') as f:
-        f.write(
-            "\n".join([
-                f"{package}=={version}" if version else f"{package}"
-                for package, version in updated_packages.items()
-            ])
-        )
+    dump_packages(updated_packages, requirements_file)
 
     added_or_updated = [f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages.items()]
     print(f"Updated {requirements_file} with {', '.join(added_or_updated)}")

--- a/pwp/commands/install.py
+++ b/pwp/commands/install.py
@@ -1,0 +1,52 @@
+import os
+import sys
+from pip._internal.cli.main import main as pip_main
+import importlib.metadata
+
+
+def get_installed_package_version(package_name):
+    """Get the installed version of a package."""
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def create_or_update_requirements(packages: dict[str, str|None]):
+    requirements_file = 'requirements.txt'
+
+    if os.path.exists(requirements_file):
+        with open(requirements_file, 'r') as f:
+            existing_packages = {
+                line.split('==')[0].strip(): line.strip() for line in f if '==' in line or line.strip()
+            }
+    else:
+        existing_packages = {}
+
+    updated_packages = existing_packages.copy()
+
+    # Update or add new packages with their versions
+    for package, version in packages.items():
+        if version:
+            updated_packages[package] = f"{package}=={version}"
+        else:
+            updated_packages[package] = package
+
+    with open(requirements_file, 'w') as f:
+        f.write("\n".join(updated_packages.values()))
+
+    added_or_updated = [f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages.items()]
+    print(f"Updated {requirements_file} with {', '.join(added_or_updated)}")
+
+
+def pwp_install():
+    if len(sys.argv) < 3:
+        print("Usage: pwp install <package_name1> [<package_name2> ...]")
+        return
+
+    packages = sys.argv[2:]
+    pip_main(['install'] + packages)
+
+    # Retrieve the installed versions
+    installed_packages = {pkg: get_installed_package_version(pkg) for pkg in packages}
+    create_or_update_requirements(installed_packages)

--- a/pwp/commands/install.py
+++ b/pwp/commands/install.py
@@ -12,7 +12,7 @@ def get_installed_package_version(package_name):
         return None
 
 
-def create_or_update_requirements(packages: dict[str, str|None]):
+def create_or_update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):
@@ -41,12 +41,20 @@ def create_or_update_requirements(packages: dict[str, str|None]):
 
 def pwp_install():
     if len(sys.argv) < 3:
-        print("Usage: pwp install <package_name1> [<package_name2> ...]")
+        print("Usage: pwp install <package_name1> [<package_name2> ...] [--v]")
         return
 
     packages = sys.argv[2:]
+    include_version = '--v' in packages
+
+    if include_version:
+        packages.remove('--v')
+
     pip_main(['install'] + packages)
 
-    # Retrieve the installed versions
-    installed_packages = {pkg: get_installed_package_version(pkg) for pkg in packages}
+    # Retrieve the installed versions if --v flag is present, else set versions to None
+    installed_packages = {
+        pkg: get_installed_package_version(pkg) if include_version else None for pkg in packages
+    }
+
     create_or_update_requirements(installed_packages)

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -1,26 +1,37 @@
 import os
 import sys
 from pip._internal.cli.main import main as pip_main
-from .utils import load_packages, dump_packages
+from .utils import load_packages, dump_packages, get_installed_package_version
 
 
 def update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):
-        existing_packages = load_packages(requirements_file)
+        existing_packages = load_packages(requirements_file, show_versions=True)
 
-        packages_to_remove = set(packages) & set(existing_packages)
+        packages_to_remove = {
+            pkg: ver for pkg, ver in packages.items()
+            if pkg in existing_packages and (ver is None or existing_packages[pkg] == ver)
+        }
+
         remaining_packages = {
-            pkg: ver for pkg, ver in existing_packages.items() if pkg not in packages_to_remove
+            pkg: ver for pkg, ver in existing_packages.items()
+            if pkg not in packages_to_remove
         }
 
         dump_packages(remaining_packages, requirements_file)
 
         if packages_to_remove:
-            print(f"Removed {', '.join(packages_to_remove)} from {requirements_file}")
+            formatted_packages = [
+                f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages_to_remove.items()
+            ]
+            print(f"Removed {', '.join(formatted_packages)} from {requirements_file}")
 
-        not_found = set(packages) - set(existing_packages)
+        not_found = [
+            f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages.items() if existing_packages.get(pkg, "") != ver
+        ]
+
         if not_found:
             print(f"Packages not found in {requirements_file}: {', '.join(not_found)}")
     else:
@@ -32,9 +43,17 @@ def pwp_uninstall():
         print("Usage: pwp uninstall <package_name1> [<package_name2> ...]")
         return
 
-    package_names = sys.argv[2:]
-    pip_main(['uninstall', '-y'] + package_names)
+    packages = sys.argv[2:]
+    pip_main(['uninstall', '-y'] + packages)
 
-    # Convert package names to a dictionary with None as the version
-    packages_to_remove = {pkg: None for pkg in package_names}
+    # Convert package names to a dictionary <name, version>
+    packages_to_remove = {}
+    for package in packages:
+        name, *rest = package.split("==")
+        if "==" in package:
+            version = rest[0]
+            packages_to_remove[name] = version
+        else:
+            packages_to_remove[name] = get_installed_package_version(name)
+
     update_requirements(packages_to_remove)

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from pip._internal.cli.main import main as pip_main
+
+
+def update_requirements(packages: dict[str, str|None]):
+    requirements_file = 'requirements.txt'
+
+    if os.path.exists(requirements_file):
+        with open(requirements_file, 'r') as f:
+            lines = f.readlines()
+            existing_packages = dict()
+            for line in lines:
+                line = line.strip()
+                if "==" not in line:
+                    existing_packages[line] = None
+                else:
+                    name, version = line.split("==")
+                    existing_packages[name] = version
+
+        packages_to_remove = set(packages) & set(existing_packages)
+        remaining_packages = {
+            pkg: ver for pkg, ver in existing_packages.items() if pkg not in packages_to_remove
+        }
+
+        with open(requirements_file, 'w') as f:
+            f.write(
+                "\n".join([
+                    f"{package}=={version}" if version else f"{package}"
+                    for package, version in remaining_packages.items()
+                ])
+            )
+
+        if packages_to_remove:
+            print(f"Removed {', '.join(packages_to_remove)} from {requirements_file}")
+
+        not_found = set(packages) - set(existing_packages)
+        if not_found:
+            print(f"Packages not found in {requirements_file}: {', '.join(not_found)}")
+    else:
+        print(f"{requirements_file} not found")
+
+
+def pwp_uninstall():
+    if len(sys.argv) < 3:
+        print("Usage: pwp uninstall <package_name1> [<package_name2> ...]")
+        return
+
+    package_names = sys.argv[2:]
+    pip_main(['uninstall', '-y'] + package_names)
+
+    # Convert package names to a dictionary with None as the version
+    packages_to_remove = {pkg: None for pkg in package_names}
+    update_requirements(packages_to_remove)

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -1,39 +1,37 @@
 import os
 import sys
 from pip._internal.cli.main import main as pip_main
-from .utils import load_packages, dump_packages, get_installed_package_version
+from .utils import load_packages, dump_packages, get_installed_package_version, format_packages, filter_packages
 
 
 def update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):
-        existing_packages = load_packages(requirements_file, show_versions=True)
+        existing_packages = load_packages(requirements_file)
 
-        packages_to_remove = {
-            pkg: ver for pkg, ver in packages.items()
-            if pkg in existing_packages and (ver is None or existing_packages[pkg] == ver)
-        }
+        packages_to_remove = filter_packages(
+            packages=packages,
+            condition=lambda pkg, ver: pkg in existing_packages
+        )
 
-        remaining_packages = {
-            pkg: ver for pkg, ver in existing_packages.items()
-            if pkg not in packages_to_remove
-        }
+        remaining_packages = filter_packages(
+            packages=existing_packages,
+            condition=lambda pkg, ver: pkg not in packages_to_remove
+        )
 
         dump_packages(remaining_packages, requirements_file)
 
         if packages_to_remove:
-            formatted_packages = [
-                f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages_to_remove.items()
-            ]
-            print(f"Removed {', '.join(formatted_packages)} from {requirements_file}")
+            print(f"Removed {', '.join(format_packages(packages_to_remove))} from {requirements_file}")
 
-        not_found = [
-            f"{pkg}=={ver}" if ver else pkg for pkg, ver in packages.items() if existing_packages.get(pkg, "") != ver
-        ]
+        not_found = filter_packages(
+            packages=packages,
+            condition=lambda pkg, ver: pkg not in existing_packages
+        )
 
         if not_found:
-            print(f"Packages not found in {requirements_file}: {', '.join(not_found)}")
+            print(f"Packages not found in {requirements_file}: {', '.join(format_packages(not_found))}")
     else:
         print(f"{requirements_file} not found")
 
@@ -49,11 +47,7 @@ def pwp_uninstall():
     # Convert package names to a dictionary <name, version>
     packages_to_remove = {}
     for package in packages:
-        name, *rest = package.split("==")
-        if "==" in package:
-            version = rest[0]
-            packages_to_remove[name] = version
-        else:
-            packages_to_remove[name] = get_installed_package_version(name)
+        name, *_ = package.split("==")
+        packages_to_remove[name] = None
 
     update_requirements(packages_to_remove)

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -1,7 +1,19 @@
+import argparse
 import os
 import sys
 from pip._internal.cli.main import main as pip_main
 from .utils import load_packages, dump_packages, get_installed_package_version, format_packages, filter_packages
+
+
+# Function to create the argument parser for the uninstall command
+def get_uninstall_parser():
+    parser = argparse.ArgumentParser(description="Uninstall Python packages.", add_help=False)
+    parser.add_argument(
+        'packages',
+        nargs='+',
+        help="List of packages to uninstall."
+    )
+    return parser
 
 
 def update_requirements(packages: dict[str, str | None]):
@@ -36,12 +48,7 @@ def update_requirements(packages: dict[str, str | None]):
         print(f"{requirements_file} not found")
 
 
-def pwp_uninstall():
-    if len(sys.argv) < 3:
-        print("Usage: pwp uninstall <package_name1> [<package_name2> ...]")
-        return
-
-    packages = sys.argv[2:]
+def pwp_uninstall(packages):
     pip_main(['uninstall', '-y'] + packages)
 
     # Convert package names to a dictionary <name, version>

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -1,34 +1,21 @@
 import os
 import sys
 from pip._internal.cli.main import main as pip_main
+from .utils import load_packages, dump_packages
 
 
 def update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):
-        with open(requirements_file, 'r') as lines:
-            existing_packages = dict()
-            for line in lines:
-                line = line.strip()
-                if "==" not in line:
-                    existing_packages[line] = None
-                else:
-                    name, version = line.split("==")
-                    existing_packages[name] = version
+        existing_packages = load_packages(requirements_file)
 
         packages_to_remove = set(packages) & set(existing_packages)
         remaining_packages = {
             pkg: ver for pkg, ver in existing_packages.items() if pkg not in packages_to_remove
         }
 
-        with open(requirements_file, 'w') as f:
-            f.write(
-                "\n".join([
-                    f"{package}=={version}" if version else f"{package}"
-                    for package, version in remaining_packages.items()
-                ])
-            )
+        dump_packages(remaining_packages, requirements_file)
 
         if packages_to_remove:
             print(f"Removed {', '.join(packages_to_remove)} from {requirements_file}")

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -7,8 +7,7 @@ def update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):
-        with open(requirements_file, 'r') as f:
-            lines = f.readlines()
+        with open(requirements_file, 'r') as lines:
             existing_packages = dict()
             for line in lines:
                 line = line.strip()

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -3,7 +3,7 @@ import sys
 from pip._internal.cli.main import main as pip_main
 
 
-def update_requirements(packages: dict[str, str|None]):
+def update_requirements(packages: dict[str, str | None]):
     requirements_file = 'requirements.txt'
 
     if os.path.exists(requirements_file):

--- a/pwp/commands/uninstall.py
+++ b/pwp/commands/uninstall.py
@@ -48,7 +48,8 @@ def update_requirements(packages: dict[str, str | None]):
         print(f"{requirements_file} not found")
 
 
-def pwp_uninstall(packages):
+def pwp_uninstall(args):
+    packages = args.packages
     pip_main(['uninstall', '-y'] + packages)
 
     # Convert package names to a dictionary <name, version>

--- a/pwp/commands/utils.py
+++ b/pwp/commands/utils.py
@@ -1,4 +1,5 @@
 import importlib.metadata
+from typing import Callable
 
 
 def get_installed_package_version(package_name):
@@ -9,24 +10,34 @@ def get_installed_package_version(package_name):
         return None
 
 
+def format_packages(packages: dict[str, str | None]) -> list[str]:
+    return [
+        f"{package}=={version}" if version else package
+        for package, version in packages.items()
+    ]
+
+
+def filter_packages(packages: dict[str, str | None], condition: Callable[[str, str], bool]):
+    return {
+        package: version for package, version in packages.items() if condition(package, version)
+    }
+
+
 def load_packages(file, show_versions=False):
     packages = {}
+
     with open(file, 'r') as lines:
         for line in lines:
-            line = line.strip()
+            name, *rest = line.strip().split("==")
+            print(line)
             if "==" not in line:
-                packages[line] = get_installed_package_version(lines) if show_versions else None
+                packages[name] = get_installed_package_version(name) if show_versions else None
             else:
-                name, version = line.split("==")
+                version = rest[0]
                 packages[name] = version
     return packages
 
 
 def dump_packages(packages, file):
     with open(file, 'w') as f:
-        f.write(
-            "\n".join([
-                f"{package}=={version}" if version else f"{package}"
-                for package, version in packages.items()
-            ])
-        )
+        f.write("\n".join(format_packages(packages)))

--- a/pwp/commands/utils.py
+++ b/pwp/commands/utils.py
@@ -1,0 +1,21 @@
+def load_packages(file):
+    packages = {}
+    with open(file, 'r') as lines:
+        for line in lines:
+            line = line.strip()
+            if "==" not in line:
+                packages[line] = None
+            else:
+                name, version = line.split("==")
+                packages[name] = version
+    return packages
+
+
+def dump_packages(packages, file):
+    with open(file, 'w') as f:
+        f.write(
+            "\n".join([
+                f"{package}=={version}" if version else f"{package}"
+                for package, version in packages.items()
+            ])
+        )

--- a/pwp/commands/utils.py
+++ b/pwp/commands/utils.py
@@ -1,10 +1,21 @@
-def load_packages(file):
+import importlib.metadata
+
+
+def get_installed_package_version(package_name):
+    """Get the installed version of a package."""
+    try:
+        return importlib.metadata.version(package_name)
+    except importlib.metadata.PackageNotFoundError:
+        return None
+
+
+def load_packages(file, show_versions=False):
     packages = {}
     with open(file, 'r') as lines:
         for line in lines:
             line = line.strip()
             if "==" not in line:
-                packages[line] = None
+                packages[line] = get_installed_package_version(lines) if show_versions else None
             else:
                 name, version = line.split("==")
                 packages[name] = version

--- a/pwp/main.py
+++ b/pwp/main.py
@@ -1,41 +1,46 @@
-import sys
-from .commands import pwp_install, pwp_uninstall
+import argparse
+from .commands.install import get_install_parser, pwp_install
+from .commands.uninstall import get_uninstall_parser, pwp_uninstall
+
+
+ascii_art = r"""
+    ░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓███████▓▒░  
+    ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+    ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
+    ░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓███████▓▒░  
+    ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
+    ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
+    ░▒▓█▓▒░       ░▒▓█████████████▓▒░░▒▓█▓▒░
+"""
 
 
 def main():
-    if len(sys.argv) < 2:
-        welcome_message = r"""
+    # Set up the main argument parser
+    parser = argparse.ArgumentParser(
+        description=f"{ascii_art}\nPip With Packages - by Kaito\n\nThanks for installing PWP!\n",
+        formatter_class=argparse.RawTextHelpFormatter,
+        epilog="Enjoy managing your packages with ease!"
+    )
 
-    ░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓███████▓▒░  
-    ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
-    ░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░░▒▓█▓▒░ 
-    ░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓███████▓▒░  
-    ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
-    ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
-    ░▒▓█▓▒░       ░▒▓█████████████▓▒░░▒▓█▓▒░        
+    # Create subparsers for 'install' and 'uninstall'
+    subparsers = parser.add_subparsers(dest='command', help="Command to execute")
 
+    # Install parser imported from install.py
+    install_parser = get_install_parser()
+    subparsers.add_parser('install', parents=[install_parser], help="Install packages")
 
-    Pip With Packages - by Kaito
+    # Uninstall parser imported from uninstall.py
+    uninstall_parser = get_uninstall_parser()
+    subparsers.add_parser('uninstall', parents=[uninstall_parser], help="Uninstall packages")
 
-    Thanks for installing PWP!
-    Usage:
-        pwp install <package1> [<package2> ...]
-        pwp uninstall <package1> [<package2> ...]
+    args = parser.parse_args()
 
-    Enjoy managing your packages with ease!
-        """
-        print(welcome_message)
-
-        return
-
-    command = sys.argv[1]
-
-    if command == 'install':
-        pwp_install()
-    elif command == 'uninstall':
-        pwp_uninstall()
+    if args.command == 'install':
+        pwp_install(args.packages, args.v)
+    elif args.command == 'uninstall':
+        pwp_uninstall(args.packages)
     else:
-        print(f"Unknown command: {command}")
+        parser.print_help()
 
 
 if __name__ == "__main__":

--- a/pwp/main.py
+++ b/pwp/main.py
@@ -36,9 +36,9 @@ def main():
     args = parser.parse_args()
 
     if args.command == 'install':
-        pwp_install(args.packages, args.v)
+        pwp_install(args)
     elif args.command == 'uninstall':
-        pwp_uninstall(args.packages)
+        pwp_uninstall(args)
     else:
         parser.print_help()
 

--- a/pwp/main.py
+++ b/pwp/main.py
@@ -1,74 +1,9 @@
-import os
 import sys
-from pip._internal.cli.main import main as pip_main
+from .commands import pwp_install, pwp_uninstall
 
-def create_or_update_requirements(package_names, action='install'):
-    requirements_file = 'requirements.txt'
-    
-    if action == 'install':
-        if not os.path.exists(requirements_file):
-            with open(requirements_file, 'w') as f:
-                for package in package_names:
-                    f.write(f"{package}\n")
-            print(f"Created {requirements_file} and added {', '.join(package_names)}")
-        else:
-            with open(requirements_file, 'r') as f:
-                existing_packages = set(line.strip() for line in f)
-            
-            new_packages = [pkg for pkg in package_names if pkg not in existing_packages]
-            
-            if new_packages:
-                with open(requirements_file, 'a') as f:
-                    for package in new_packages:
-                        f.write(f"{package}\n")
-                print(f"Added {', '.join(new_packages)} to {requirements_file}")
-            
-            existing = set(package_names) & existing_packages
-            if existing:
-                print(f"Packages already in {requirements_file}: {', '.join(existing)}")
-    
-    elif action == 'uninstall':
-        if os.path.exists(requirements_file):
-            with open(requirements_file, 'r') as f:
-                packages = set(line.strip() for line in f)
-            
-            packages_to_remove = set(package_names) & packages
-            remaining_packages = packages - packages_to_remove
-            
-            with open(requirements_file, 'w') as f:
-                for package in remaining_packages:
-                    f.write(f"{package}\n")
-            
-            if packages_to_remove:
-                print(f"Removed {', '.join(packages_to_remove)} from {requirements_file}")
-            
-            not_found = set(package_names) - packages
-            if not_found:
-                print(f"Packages not found in {requirements_file}: {', '.join(not_found)}")
-        else:
-            print(f"{requirements_file} not found")
-
-def pwp_install():
-    if len(sys.argv) < 3:
-        print("Usage: pwp install <package_name1> [<package_name2> ...]")
-        return
-
-    package_names = sys.argv[2:]
-    pip_main(['install'] + package_names)
-    create_or_update_requirements(package_names, 'install')
-
-def pwp_uninstall():
-    if len(sys.argv) < 3:
-        print("Usage: pwp uninstall <package_name1> [<package_name2> ...]")
-        return
-
-    package_names = sys.argv[2:]
-    pip_main(['uninstall', '-y'] + package_names)
-    create_or_update_requirements(package_names, 'uninstall')
 
 def main():
     if len(sys.argv) < 2:
-    
         welcome_message = r"""
 
     ░▒▓███████▓▒░░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓███████▓▒░  
@@ -78,19 +13,18 @@ def main():
     ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
     ░▒▓█▓▒░      ░▒▓█▓▒░░▒▓█▓▒░░▒▓█▓▒░▒▓█▓▒░        
     ░▒▓█▓▒░       ░▒▓█████████████▓▒░░▒▓█▓▒░        
-                                                
-                                                    
+
+
     Pip With Packages - by Kaito
-    
+
     Thanks for installing PWP!
     Usage:
         pwp install <package1> [<package2> ...]
         pwp uninstall <package1> [<package2> ...]
-    
+
     Enjoy managing your packages with ease!
         """
         print(welcome_message)
-        
 
         return
 
@@ -102,6 +36,7 @@ def main():
         pwp_uninstall()
     else:
         print(f"Unknown command: {command}")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
### PR Summary

This PR introduces a `--v` flag to the installation script, allowing users to optionally include the installed package versions in the requirements.txt file.

When the `--v` flag is used, the script will record the exact versions of the installed packages; otherwise, only the package names will be listed without versions.